### PR TITLE
Add Danish Vocab Trainer project

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,19 @@ Firebase Hosting
 
 🇩🇰 Danish Vocab Trainer
 
-Danish Vocab Trainer is a Python program that helps learners practice Danish vocabulary using flashcards and quizzes.
+A web-based application designed to help users improve their Danish vocabulary through interactive study modes. It features vocabulary lists, quizzes, and flashcards to facilitate efficient language learning and retention. The app is user-friendly and accessible on any device via the browser.
 
-🚀 Features
-✅ Interactive flashcards and quizzes
-📈 Progress tracking
-📝 Import vocabulary from CSV files
+## Features
+
+- Interactive vocabulary flashcards for effective memorization  
+- Quiz mode to test and reinforce learning  
+- Organized word lists categorized by topics or lessons  
+- Responsive design for use on desktop and mobile devices   
+- Simple and intuitive user interface for easy navigation  
+
+
 🛠 Tech Stack
-Python 3
+HTML
+CSS
+Javascript
+Github Hosting

--- a/README.md
+++ b/README.md
@@ -15,3 +15,14 @@ HTML5
 CSS3
 JavaScript
 Firebase Hosting
+
+🇩🇰 Danish Vocab Trainer
+
+Danish Vocab Trainer is a Python program that helps learners practice Danish vocabulary using flashcards and quizzes.
+
+🚀 Features
+✅ Interactive flashcards and quizzes
+📈 Progress tracking
+📝 Import vocabulary from CSV files
+🛠 Tech Stack
+Python 3

--- a/index.html
+++ b/index.html
@@ -68,20 +68,24 @@
 
             <li><h3>🇩🇰 Danish Vocab Trainer</h3>
 
-                <p><strong>GitHub:</strong> <a href="https://github.com/GraceDuquiza/Danish_Vocab_Trainer" target="_blank">GraceDuquiza/Danish_Vocab_Trainer</a></p>
+                <p><strong>GitHub:</strong> <a href="https://graceduquiza.github.io/Danish_Vocab_Trainer/" target="_blank">Danish_Vocab_Trainer</a></p>
 
-                <p><strong>Danish Vocab Trainer</strong> is a Python project designed to help learners practice Danish vocabulary using flashcards and quizzes.</p>
+                <p><strong>Danish Vocab Trainer</strong> A web-based application designed to help users improve their Danish vocabulary through interactive study modes. It features vocabulary lists, quizzes, and flashcards to facilitate efficient language learning and retention. The app is user-friendly and accessible on any device via the browser. </p>
 
                 <h3>🚀 Features</h3>
                 <ul>
-                    <li>✅ Interactive flashcards</li>
-                    <li>📈 Tracks learning progress</li>
-                    <li>📝 Import vocabulary from CSV files</li>
+                    <li>Interactive vocabulary flashcards for effective memorization</li>
+                    <li>Quiz mode to test and reinforce learning</li>
+                    <li>Organized word lists categorized by topics or lessons</li>
+                    <li>Responsive design for use on desktop and mobile devices</li>
                 </ul>
 
                 <h3>🛠 Tech Stack</h3>
                 <ul>
-                    <li>Python 3</li>
+                    <li>HTML</li>
+                    <li>CSS</li>
+                    <li>Javascript</li>
+                    <li>Github hosting</li>
                 </ul>
             </li>
 

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
                     <li>🍱 Menu showcase with siomai options</li>
                     <li>🔥 Deployed using Firebase Hosting</li>
                 </ul>
-                
+
                 <h3>🛠 Tech Stack</h3>
                 <ul>
                     <li>HTML5</li>
@@ -64,8 +64,27 @@
                     <li>JavaScript</li>
                     <li>Firebase Hosting</li>
                 </ul>
-                </li>
-            
+            </li>
+
+            <li><h3>🇩🇰 Danish Vocab Trainer</h3>
+
+                <p><strong>GitHub:</strong> <a href="https://github.com/GraceDuquiza/Danish_Vocab_Trainer" target="_blank">GraceDuquiza/Danish_Vocab_Trainer</a></p>
+
+                <p><strong>Danish Vocab Trainer</strong> is a Python project designed to help learners practice Danish vocabulary using flashcards and quizzes.</p>
+
+                <h3>🚀 Features</h3>
+                <ul>
+                    <li>✅ Interactive flashcards</li>
+                    <li>📈 Tracks learning progress</li>
+                    <li>📝 Import vocabulary from CSV files</li>
+                </ul>
+
+                <h3>🛠 Tech Stack</h3>
+                <ul>
+                    <li>Python 3</li>
+                </ul>
+            </li>
+
         </ul>
     </section>
 


### PR DESCRIPTION
## Summary
- add details for Danish Vocab Trainer project in README
- list Danish Vocab Trainer in Projects section on website

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6850123714808320bb50f9a730609d58

## Summary by Sourcery

Add Danish Vocab Trainer project information to the site and README

New Features:
- List Danish Vocab Trainer in the website’s Projects section with link, features, and tech stack

Documentation:
- Update README with Danish Vocab Trainer description, features, and tech stack